### PR TITLE
Content stream

### DIFF
--- a/R/bagit.R
+++ b/R/bagit.R
@@ -1,5 +1,29 @@
+bagit_query <- function(identifier,
+                        dir = app_dir()) {
+  registry <- bagit_manifest(dir)
+  
+  hash <- strip_prefix(identifier)
+  df <- readr::read_delim(registry,
+                          delim = " ",
+                          col_names = c("identifier", "source"),
+                          col_types = "cc"
+  )
+  
+  if (length(df) == 0) {
+    return(df)
+  }
+  
+  out <- df[df[[1]] == hash, ]
+  
+  format_bagit(out)
+  
+}
+
+
+
 #' @importFrom fs file_create file_exists path_abs
-bagit_manifest_create <- function(dir = app_dir()) {
+bagit_manifest <- function(dir = app_dir()) {
+  
   path <- fs::path_abs("manifest-sha256.txt", dir)
   bagit <- fs::path_abs("bagit.txt", dir)
 
@@ -18,26 +42,10 @@ bagit_manifest_create <- function(dir = app_dir()) {
   path
 }
 
-bagit_query <- function(identifier,
-                        dir = app_dir()) {
-  registry <- bagit_manifest_create(dir)
 
-  hash <- strip_prefix(identifier)
-  df <- readr::read_delim(registry,
-    delim = " ",
-    col_names = c("identifier", "source"),
-    col_types = "cc"
-  )
-
-  if (length(df) == 0) {
-    return(df)
-  }
-
-  df[df[[1]] == hash, ]
-}
 
 bagit_add <- function(dir = app_dir(), identifier, source) {
-  registry <- bagit_manifest_create(dir)
+  registry <- bagit_manifest(dir)
 
   ## we don't want to create duplicate entries
   df <- bagit_query(identifier, dir)
@@ -49,12 +57,14 @@ bagit_add <- function(dir = app_dir(), identifier, source) {
     identifier = strip_prefix(identifier),
     source = fs::path_rel(source, start = dir)
   )
+  
   readr::write_delim(row, registry, append = TRUE)
 }
 
 
+
 # takes the result of a `df <- bagit_query(uri)`
-# and formats it like registry_query
+# and formats it like a registry_query
 #' @importFrom fs file_info path_abs
 format_bagit <- function(df, dir = app_dir()) {
   if (ncol(df) == 0 || nrow(df) == 0) {

--- a/R/content-uri.R
+++ b/R/content-uri.R
@@ -33,7 +33,7 @@
 content_uri <- function(file, open = "", raw = TRUE) {
   
   
-  con <- read_stream(file, open = open, raw = raw)
+  con <- stream_connection(file, open = open, raw = raw)
   ## Could support other hash types
   hash <- openssl::sha256(con)
   paste0("hash://sha256/", as.character(hash))
@@ -42,7 +42,7 @@ content_uri <- function(file, open = "", raw = TRUE) {
 
 ## Hash archive computes and stores hashes as this:
 content_hashes <- function(path) {
-  cons <- lapply(path, read_stream, raw = raw)
+  cons <- lapply(path, stream_connection, raw = raw)
   hashes <- lapply(
     cons,
     function(con) {

--- a/R/content-uri.R
+++ b/R/content-uri.R
@@ -2,22 +2,24 @@
 
 
 #' Generate a content uri for a local file
-#' @param path path to the file
-#' @param raw logical, whether the content should be for the raw file
-#'  or contents, see [base::file]
-#' @param ... additional arguments to [base::file]
+#' @param file path to the file, URL, or a [base::file] connection
+#' @param open The mode to open text, see details for `Mode` in [base::file].
+#' @param raw Logical, should compressed data be left as compressed binary?
 #' @details
 #'
 #' See <https://github.com/hash-uri/hash-uri> for an overview of the
 #'  content uri format and comparison to similar approaches.
 #'
 #' Compressed file streams will have different raw (binary) and uncompressed
-#'  hashes. Set `raw = FALSE` will allow [file] connection to uncompress 
+#'  hashes. Set `raw = FALSE` to allow [base::file] connection to uncompress 
 #'  common compression streams before calculating the hash, but this will
 #'  be slower.
 #'
 #' @return a content identifier uri
-#'
+#' 
+#' @export
+#' @importFrom openssl sha256
+#' 
 #' @examples
 #' path <- tempfile("iris", , ".csv")
 #' write.csv(iris, path)
@@ -27,20 +29,20 @@
 #' path_txt <- tempfile("iris", , ".txt")
 #' write.table(iris, path_txt)
 #' content_uri(path_txt)
-#' @export
-#' @importFrom openssl sha256
-content_uri <- function(path, raw = TRUE, ...) {
-  con <- lapply(path, base::file, raw = raw, ...)
-  ## Should support other hash types
-  hash <- lapply(con, openssl::sha256)
-
-  paste0("hash://sha256/", vapply(hash, as.character, character(1L)))
+#' 
+content_uri <- function(file, open = "", raw = TRUE) {
+  
+  
+  con <- read_stream(file, open = open, raw = raw)
+  ## Could support other hash types
+  hash <- openssl::sha256(con)
+  paste0("hash://sha256/", as.character(hash))
 }
 
 
 ## Hash archive computes and stores hashes as this:
-content_hashes <- function(path, ...) {
-  cons <- lapply(path, base::file, raw = raw, open = "rb")
+content_hashes <- function(path) {
+  cons <- lapply(path, read_stream, raw = raw)
   hashes <- lapply(
     cons,
     function(con) {

--- a/R/query.R
+++ b/R/query.R
@@ -91,10 +91,9 @@ query_remote <- function(uri) {
 query_local <- function(uri, dir = app_dir()) {
   registry <- registry_create(dir)
   if (is_content_uri(uri)) {
+    
     url_df <- registry_get_hash(uri, registry)
-
-    df <- bagit_query(uri, dir)
-    path_df <- format_bagit(df, dir)
+    path_df <- bagit_query(uri, dir)
 
     rbind(path_df, url_df)
   }

--- a/R/register.R
+++ b/R/register.R
@@ -127,17 +127,16 @@ register_remote <- function(url) {
 #'
 register_local <- function(url, dir = app_dir()) {
   # (downloads resource to temp dir only)
-  x <- download_resource(url)
-  meta <- entry_metadata(x)
-
+  id <- content_uri(url)
+  
   registry_add(
     dir,
-    meta$identifier,
+    id,
     url,
-    meta$date
+    Sys.time()
   )
 
-  meta$identifier
+  id
 }
 
 

--- a/R/store.R
+++ b/R/store.R
@@ -40,16 +40,6 @@ store <- function(x, dir = app_dir()) {
   meta <- entry_metadata(x)
 
 
-  ## Register the URL as a location
-  if (!is.null(url)) {
-    registry_add(
-      dir,
-      meta$identifier,
-      url,
-      meta$date
-    )
-  }
-
   ## Here we actually copy the data into the local store
   stored_path <- store_shelve(x, meta$identifier, dir = dir)
 

--- a/R/store.R
+++ b/R/store.R
@@ -28,64 +28,59 @@
 store <- function(x, dir = app_dir()) {
   # Consider vectorizing of x?
 
-  ## ick extra logic so we can register the url location as well,
-  ## (without duplicating calls to download or hash)
-  url <- NULL
-  if (is_url(x)) {
-    url <- x
-    x <- download_resource(x)
-  }
+  ## download to temp dir if necessary. We cannot 
+  ## stream into store since we must first compute address from id
+  con <- stream_connection(x, download = TRUE)
+  on.exit(close(con))
 
   ## Compute the Content Hash URI and other metadata
-  meta <- entry_metadata(x)
-
+  id <- content_uri(con)
 
   ## Here we actually copy the data into the local store
-  stored_path <- store_shelve(x, meta$identifier, dir = dir)
+  ## Using paths and file.copy() is much faster than streaming
+  path <- summary(con)$description
+  stored_path <- store_shelve(path, id, dir = dir)
 
   ## And we register that location as well
   ## Local paths are registered following BagIt manifest format instead
   bagit_add(
     dir,
-    meta$identifier,
+    id,
     stored_path
   )
 
-  meta$identifier
+  id
 }
 
 
 ## Shelve the object based on its content_uri
-store_shelve <- function(file, hash = NULL, dir = app_dir()) {
-
-  ## In general these steps will have been performed already:
-  file <- download_resource(file)
-  if (is.null(hash)) {
-    hash <- content_uri(file)
-  }
-
+store_shelve <- function(path, id = content_uri(file), dir = app_dir()) {
+  
   ## Determine the storage location and move the file to that location
-  dest <- hash_path(hash, dir)
-  file.copy(file, dest, overwrite = TRUE) 
-  # Technically should silently skip overwrite instead
+  dest <- content_based_location(id, dir)
+  if(!fs::file_exists(dest))
+    fs::file_copy(path, dest)
+  
+   ## Alternately, for an open connection, but slower
+   # stream_binary(con, dest)
 
   dest
 }
 
 
 store_retrieve <- function(x, dir = app_dir()) {
-  if (!is_content_uri(x)) 
+  if (!is_content_uri(x)){ 
     stop(paste(x, "is not a recognized content uri"), call. = FALSE)
+  }
 
-  path <- hash_path(x, dir)
+  path <- content_based_location(x, dir)
 
   if (!file.exists(path)) {
-    return(warning(paste(
+    warning(paste(
       "No stored file found for", x,
-      "in", dir
-    ),
+      "in", dir),
     call. = FALSE
-    ))
+    )
   }
   path
 }
@@ -93,7 +88,7 @@ store_retrieve <- function(x, dir = app_dir()) {
 
 # hate to add a dependency but `fs` is so much better about file paths
 #' @importFrom fs path_rel path
-hash_path <- function(hash, dir = app_dir()) {
+content_based_location <- function(hash, dir = app_dir()) {
   ## use 2-level nesting
   hash <- strip_prefix(hash)
   sub1 <- gsub("^(\\w{2}).*", "\\1", hash)

--- a/R/store.R
+++ b/R/store.R
@@ -41,14 +41,6 @@ store <- function(x, dir = app_dir()) {
   path <- summary(con)$description
   stored_path <- store_shelve(path, id, dir = dir)
 
-  ## And we register that location as well
-  ## Local paths are registered following BagIt manifest format instead
-  bagit_add(
-    dir,
-    id,
-    stored_path
-  )
-
   id
 }
 
@@ -76,14 +68,27 @@ store_retrieve <- function(x, dir = app_dir()) {
   path <- content_based_location(x, dir)
 
   if (!file.exists(path)) {
-    warning(paste(
-      "No stored file found for", x,
-      "in", dir),
-    call. = FALSE
-    )
+    message(paste("No stored file found for", x, "in", dir),
+            call. = FALSE)
+    return(NULL)
   }
+  
+  ## We could call `file(path)` instead, but would make assumptions about how
+  ## we were reading the content that are better left to the user?
   path
 }
+
+store_list <- function(dir = app_dir()){
+  fs::dir_info(path = fs::path(dir, "data"), recurse = TRUE, type = "file")
+}
+
+store_delete <- function(ids, dir = app_dir()){
+  lapply(ids, function(id){ 
+    path <- content_based_location(id, dir)
+    fs::file_delete(path)
+  })
+}
+
 
 
 # hate to add a dependency but `fs` is so much better about file paths

--- a/R/utils.R
+++ b/R/utils.R
@@ -31,7 +31,7 @@ download_resource <- function(x) {
 add_prefix <- function(x) paste0("hash://sha256/", x)
 strip_prefix <- function(x) gsub("^hash://sha256/", "", x)
 is_content_uri <- function(x) grepl("^hash://sha256/", x)
-is_url <- function(x) grepl("^(https?|ftps?)://.*$", x)
+is_url <- function(x) grepl("^((http|ftp)s?|sftp)://", x)
 
 ## A configurable default location for persistent data storage
 #' @importFrom rappdirs user_data_dir
@@ -42,3 +42,42 @@ app_dir <- function(dir = Sys.getenv(
   if (!fs::dir_exists(dir)) fs::dir_create(dir)
   dir
 }
+
+
+read_stream <- function(file, open = "rb", raw = TRUE){
+  
+  if (inherits(file, "connection")) {
+    return(file)
+  }
+  
+  ## URL connection
+  if (is_url(file)) {
+    if (requireNamespace("curl", quietly = TRUE)) {
+      con <- curl::curl(file)
+    }
+    else {
+      message("`curl` package not installed, falling back to using `url()`")
+      con <- url(file)
+    }
+    return(con)
+  }
+  
+  ## Path Name
+  if (is.character(file)) {
+    file <- file(file, open = open, raw = raw) 
+    ## cannot close on exit, but we register a finalizer?
+    env <-  parent.env(environment())
+    reg.finalizer(env, function(env) close(file))
+  }
+  if (!inherits(file, "connection")) 
+    stop("'file' must be a character string or connection")
+  
+  ## Do we want to open the file? maybe not
+  # if (!isOpen(file, open)) {
+  #  open(file, open = open, raw = raw)
+  #  env <- parent.env(environment())
+  #  reg.finalizer(env, function(env) close(file))
+  # }
+  file
+}
+

--- a/man/content_uri.Rd
+++ b/man/content_uri.Rd
@@ -4,15 +4,14 @@
 \alias{content_uri}
 \title{Generate a content uri for a local file}
 \usage{
-content_uri(path, raw = TRUE, ...)
+content_uri(file, open = "", raw = TRUE)
 }
 \arguments{
-\item{path}{path to the file}
+\item{file}{path to the file, URL, or a \link[base:file]{base::file} connection}
 
-\item{raw}{logical, whether the content should be for the raw file
-or contents, see \link[base:file]{base::file}}
+\item{open}{The mode to open text, see details for \code{Mode} in \link[base:file]{base::file}.}
 
-\item{...}{additional arguments to \link[base:file]{base::file}}
+\item{raw}{Logical, should compressed data be left as compressed binary?}
 }
 \value{
 a content identifier uri
@@ -25,7 +24,7 @@ See \url{https://github.com/hash-uri/hash-uri} for an overview of the
 content uri format and comparison to similar approaches.
 
 Compressed file streams will have different raw (binary) and uncompressed
-hashes. Set \code{raw = FALSE} will allow \link{file} connection to uncompress
+hashes. Set \code{raw = FALSE} to allow \link[base:file]{base::file} connection to uncompress
 common compression streams before calculating the hash, but this will
 be slower.
 }
@@ -38,4 +37,5 @@ content_uri(path)
 path_txt <- tempfile("iris", , ".txt")
 write.table(iris, path_txt)
 content_uri(path_txt)
+
 }

--- a/tests/testthat/test-content_uri.R
+++ b/tests/testthat/test-content_uri.R
@@ -4,13 +4,19 @@ test_that("content_uri returns the expected identifier", {
 
   ## Windows CI platforms will check out package from git, and
   ## in the process alter the line endings and thus the hash
-
-  ## We will uncompress the compressed version to get the original
-  ## expected content uri on all platforms
+  ## of the uncompressed vostok.icecore.co2.  The .gz version
+  ## is not effected by Windows git line-ending conversion.
   f <- system.file("extdata", "vostok.icecore.co2.gz",
     package = "contenturi", mustWork = TRUE
   )
-  id <- content_uri(f, raw = FALSE)
+  
+  ## We will uncompress the compressed version to get the original
+  ## expected content uri on all platforms  
+  con <- file(f, "", raw = FALSE)
+ 
+  ## This id should match that of the uncompressed content (on any platform!)
+  id <- content_uri(con)
+  
   expect_identical(
     id,
     paste0("hash://sha256/", 

--- a/tests/testthat/test-content_uri.R
+++ b/tests/testthat/test-content_uri.R
@@ -1,6 +1,6 @@
 context("content_uri")
 
-test_that("content_uri returns the expected identifier", {
+test_that("content_uri parses compressed file connection correctly", {
 
   ## Windows CI platforms will check out package from git, and
   ## in the process alter the line endings and thus the hash
@@ -24,3 +24,43 @@ test_that("content_uri returns the expected identifier", {
            "ba6b7bdd04bb99a4dbb21ddff646287e37")
   )
 })
+
+
+
+test_that("content_uri streams url connections", {
+
+  skip_on_cran()
+  skip_if_offline()
+
+  co2_url <- "https://zenodo.org/record/3678928/files/vostok.icecore.co2"
+  
+  id <- content_uri(co2_url)
+  expect_identical(
+    id,
+    paste0("hash://sha256/", 
+           "9412325831dab22aeebdd674b6eb53",
+           "ba6b7bdd04bb99a4dbb21ddff646287e37")
+  )
+})
+
+
+
+test_that("content_uri works with direct path", {
+  
+  skip_on_cran()
+  skip_if_offline()
+
+  ## Note this time we leave compressed so hash should be different
+  ## then the above examples
+  f <- system.file("extdata", "vostok.icecore.co2.gz",
+                   package = "contenturi", mustWork = TRUE
+  )
+  id <- content_uri(f)
+  expect_identical(
+    id,
+    paste0("hash://sha256/", 
+           "9362a6102437bff5ea508988426d527",
+           "4a8addfdb11a603d016a7b305cf66868f")
+  )
+})
+

--- a/tests/testthat/test-store.R
+++ b/tests/testthat/test-store.R
@@ -8,9 +8,9 @@ test_that("We can store local files", {
     "vostok.icecore.co2.gz",
     package = "contenturi"
   )
-  x <- store(vostok_co2)
+  id <- store(vostok_co2)
   expect_identical(
-    x,
+    id,
     paste0(
       "hash://sha256/",
       "9362a6102437bff5ea508988426d5274",
@@ -22,7 +22,7 @@ test_that("We can store local files", {
 
 
   ## Verify that object is in the store
-  path <- store_retrieve(x)
+  path <- store_retrieve(id)
   expect_true(file.exists(path))
 })
 
@@ -38,7 +38,8 @@ test_that("We can store remote files", {
   df <- query_local(x)
   expect_true(dim(df)[1] > 0)
 
+  ## We will no longer automatically register the url, store isn't a registry
   # Confirm this url is in the registry
-  df <- query_local(url)
-  expect_true(dim(df)[1] > 0)
+  #df <- query_local(url)
+  #expect_true(dim(df)[1] > 0)
 })


### PR DESCRIPTION
This PR modifies the `content_uri` function so that it works with generic content streams (blobs, bits 'n bytes) rather than with file paths.  Following typical R conventions, the function understands 'generic' notions of content stream, which can be passed as a `connection` object (see https://www.rdocumentation.org/packages/base/versions/3.6.2/topics/connections) a path to a local file, or a URL (which will be streamed through a `base::url()` connection or `curl::curl()` connection, if available.  

This same method is used now in the local `register()`, streaming the url or other connection directly, rather than the previous implementation which tried to first detect urls and then download the file to temp directory.  

`store()` is currently still calling `curl_download()` rather than `curl::curl()` stream, since streaming doesn't preserve the bits and bytes and we want them in storage.  I think `store()` needs more rethinking generally, but we can discuss further in #13 .  